### PR TITLE
Update header navigation to match actual IndiGo design

### DIFF
--- a/nav.html
+++ b/nav.html
@@ -16,65 +16,11 @@
     <div>
         <div class="default-content-wrapper">
             <ul>
-                <li><a href="/web-checkin">Checkin</a></li>
-                <li><a href="/manage">Manage</a>
-                    <ul>
-                        <li><a href="/edit-booking">Edit Booking</a></li>
-                        <li><a href="/change-flight">Change Flight</a></li>
-                        <li><a href="/baggage-tag">Baggage Tag</a></li>
-                        <li><a href="/plan-b">Plan B</a></li>
-                    </ul>
-                </li>
-                <li><a href="/6e-rewards">6E Rewards</a></li>
-                <li><a href="/info">Info</a>
-                    <ul>
-                        <li><a href="/flight-status">Flight status</a></li>
-                        <li><a href="/cargo-services">Cargo Services</a></li>
-                        <li><a href="/fees-charges">Fees & Charges</a></li>
-                        <li><a href="/destinations">Destinations</a></li>
-                        <li><a href="/seat-aircraft-info">Seat/Aircraft information</a></li>
-                        <li><a href="/covid-19">COVID-19 queries</a></li>
-                        <li><a href="/faqs">FAQs</a></li>
-                        <li><a href="/additional-info">Additional Info</a></li>
-                        <li><a href="/contact-us">Contact Us</a></li>
-                    </ul>
-                </li>
-                <li><a href="/services-offers">Services & Offers</a>
-                    <ul>
-                        <li><a href="/6e-rewards">6E Rewards</a></li>
-                        <li><a href="/6e-holidays">6E Holidays</a></li>
-                        <li><a href="/addons-services">Add-ons & Services</a>
-                            <ul>
-                                <li><a href="/6e-prime">6E Prime</a></li>
-                                <li><a href="/6e-flex">6E Flex</a></li>
-                                <li><a href="/fast-forward">Fast Forward</a></li>
-                                <li><a href="/6e-eats">6E Eats (Snacks)</a></li>
-                                <li><a href="/excess-baggage">Excess Baggage</a></li>
-                                <li><a href="/indigo-promise">IndiGo Promise</a></li>
-                                <li><a href="/unaccompanied-minor">Unaccompanied Minor</a></li>
-                                <li><a href="/indigo-early">IndiGo Early</a></li>
-                                <li><a href="/6e-special-offers">6E Special Offers</a></li>
-                            </ul>
-                        </li>
-                        <li><a href="/destinations">Our Destinations</a>
-                            <ul>
-                                <li><a href="/indian-destinations">Indian Destinations</a></li>
-                                <li><a href="/international-destinations">International Destinations</a></li>
-                            </ul>
-                        </li>
-                        <li><a href="/cargo-services">CarGo Services</a></li>
-                        <li><a href="/group-bookings">Group Booking(s)</a></li>
-                    </ul>
-                </li>
-                <li><a href="/get-inspired">Get Inspired</a></li>
-                <li><a href="/special-assistance">Special Assistance</a>
-                    <ul>
-                        <li><a href="/disability-assistance">Disability Assistance</a></li>
-                        <li><a href="/special-assistance">Special Assistance</a></li>
-                        <li><a href="/track-bag">Track your bag</a></li>
-                        <li><a href="/others">Others</a></li>
-                    </ul>
-                </li>
+                <li><a href="/book">Book</a></li>
+                <li><a href="/trips">Trips</a></li>
+                <li><a href="/deals-and-offers">Deals And Offers</a></li>
+                <li><a href="/check-in">Check-In</a></li>
+                <li><a href="/indigo-blue-chip">Indigo Blue chip</a></li>
             </ul>
         </div>
     </div>
@@ -82,26 +28,7 @@
     <!-- Tools section (becomes nav-tools) -->
     <div>
         <ul>
-            <li><a href="/login">Login</a>
-                <ul>
-                    <li><a href="/customer-login">Customer Login</a></li>
-                    <li><a href="/partner-login">Partner Login</a></li>
-                    <li><a href="/corp-connect-login">Corp Connect Login</a></li>
-                </ul>
-            </li>
-            <li><a href="/profile">View Profile</a>
-                <ul>
-                    <li><a href="/indigo-cash">IndiGo Cash</a></li>
-                    <li><a href="/my-bookings">My Bookings</a></li>
-                    <li><a href="/account-settings">My Account & Settings</a></li>
-                </ul>
-            </li>
-            <li><a href="/download-app">Download App</a></li>
-            <li><a href="/investor-relations">Investor Relations</a></li>
-            <li><a href="/weather-advisory">Weather advisory</a></li>
-            <li><a href="/careers">Careers</a></li>
-            <li><a href="/advertise">Advertise with us</a></li>
-            <li><a href="/contact-us">Contact Us</a></li>
+            <li><a href="/login">Login</a></li>
         </ul>
     </div>
 </body>

--- a/nav.plain.html
+++ b/nav.plain.html
@@ -9,65 +9,11 @@
 <div>
     <div class="default-content-wrapper">
         <ul>
-            <li><a href="/web-checkin">Checkin</a></li>
-            <li><a href="/manage">Manage</a>
-                <ul>
-                    <li><a href="/edit-booking">Edit Booking</a></li>
-                    <li><a href="/change-flight">Change Flight</a></li>
-                    <li><a href="/baggage-tag">Baggage Tag</a></li>
-                    <li><a href="/plan-b">Plan B</a></li>
-                </ul>
-            </li>
-            <li><a href="/6e-rewards">6E Rewards</a></li>
-            <li><a href="/info">Info</a>
-                <ul>
-                    <li><a href="/flight-status">Flight status</a></li>
-                    <li><a href="/cargo-services">Cargo Services</a></li>
-                    <li><a href="/fees-charges">Fees & Charges</a></li>
-                    <li><a href="/destinations">Destinations</a></li>
-                    <li><a href="/seat-aircraft-info">Seat/Aircraft information</a></li>
-                    <li><a href="/covid-19">COVID-19 queries</a></li>
-                    <li><a href="/faqs">FAQs</a></li>
-                    <li><a href="/additional-info">Additional Info</a></li>
-                    <li><a href="/contact-us">Contact Us</a></li>
-                </ul>
-            </li>
-            <li><a href="/services-offers">Services & Offers</a>
-                <ul>
-                    <li><a href="/6e-rewards">6E Rewards</a></li>
-                    <li><a href="/6e-holidays">6E Holidays</a></li>
-                    <li><a href="/addons-services">Add-ons & Services</a>
-                        <ul>
-                            <li><a href="/6e-prime">6E Prime</a></li>
-                            <li><a href="/6e-flex">6E Flex</a></li>
-                            <li><a href="/fast-forward">Fast Forward</a></li>
-                            <li><a href="/6e-eats">6E Eats (Snacks)</a></li>
-                            <li><a href="/excess-baggage">Excess Baggage</a></li>
-                            <li><a href="/indigo-promise">IndiGo Promise</a></li>
-                            <li><a href="/unaccompanied-minor">Unaccompanied Minor</a></li>
-                            <li><a href="/indigo-early">IndiGo Early</a></li>
-                            <li><a href="/6e-special-offers">6E Special Offers</a></li>
-                        </ul>
-                    </li>
-                    <li><a href="/destinations">Our Destinations</a>
-                        <ul>
-                            <li><a href="/indian-destinations">Indian Destinations</a></li>
-                            <li><a href="/international-destinations">International Destinations</a></li>
-                        </ul>
-                    </li>
-                    <li><a href="/cargo-services">CarGo Services</a></li>
-                    <li><a href="/group-bookings">Group Booking(s)</a></li>
-                </ul>
-            </li>
-            <li><a href="/get-inspired">Get Inspired</a></li>
-            <li><a href="/special-assistance">Special Assistance</a>
-                <ul>
-                    <li><a href="/disability-assistance">Disability Assistance</a></li>
-                    <li><a href="/special-assistance">Special Assistance</a></li>
-                    <li><a href="/track-bag">Track your bag</a></li>
-                    <li><a href="/others">Others</a></li>
-                </ul>
-            </li>
+            <li><a href="/book">Book</a></li>
+            <li><a href="/trips">Trips</a></li>
+            <li><a href="/deals-and-offers">Deals And Offers</a></li>
+            <li><a href="/check-in">Check-In</a></li>
+            <li><a href="/indigo-blue-chip">Indigo Blue chip</a></li>
         </ul>
     </div>
 </div>
@@ -75,25 +21,6 @@
 <!-- Tools section (becomes nav-tools) -->
 <div>
     <ul>
-        <li><a href="/login">Login</a>
-            <ul>
-                <li><a href="/customer-login">Customer Login</a></li>
-                <li><a href="/partner-login">Partner Login</a></li>
-                <li><a href="/corp-connect-login">Corp Connect Login</a></li>
-            </ul>
-        </li>
-        <li><a href="/profile">View Profile</a>
-            <ul>
-                <li><a href="/indigo-cash">IndiGo Cash</a></li>
-                <li><a href="/my-bookings">My Bookings</a></li>
-                <li><a href="/account-settings">My Account & Settings</a></li>
-            </ul>
-        </li>
-        <li><a href="/download-app">Download App</a></li>
-        <li><a href="/investor-relations">Investor Relations</a></li>
-        <li><a href="/weather-advisory">Weather advisory</a></li>
-        <li><a href="/careers">Careers</a></li>
-        <li><a href="/advertise">Advertise with us</a></li>
-        <li><a href="/contact-us">Contact Us</a></li>
+        <li><a href="/login">Login</a></li>
     </ul>
 </div> 


### PR DESCRIPTION
- Simplified navigation to match the real IndiGo header layout
- Main navigation: Book, Trips, Deals And Offers, Check-In, Indigo Blue chip
- Tools section: Login only
- Removed extensive menu items that weren't in the actual design
- Header now matches the provided design reference

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--sausaxen-indigo--aemdemos.aem.live/
- After: https://<branch>--sausaxen-indigo--aemdemos.aem.live/
